### PR TITLE
Bug in Voltage reading

### DIFF
--- a/HWDetCS/CPUBase.xaml.cs
+++ b/HWDetCS/CPUBase.xaml.cs
@@ -88,18 +88,19 @@ namespace HWDetCS
         
         public void OnCPUDetEvent(Object obj, ElapsedEventArgs args)
         {
-            //Console.WriteLine("Event Fire!");
-
-            
-
             CPUPropDet();
             
-            // Get the current clock speed
+            // Get the current clock speed safely
             CPUSpeed = values[10] + "MHz";
-            // Get the current Voltage
-            CPUVolts = (Convert.ToDouble(values[11]) / 10).ToString() + " Volts";
 
-            
+
+            // Get the current Voltage safely
+            try
+            {
+                CPUVolts = (Convert.ToDouble(values[11]) / 10).ToString() + " Volts";
+            } catch (FormatException e) {
+                CPUVolts = "Voltage Error";
+            }
         }
 
 


### PR DESCRIPTION
There was a bug in VS where the one of the debugging controls near the top of the window for WPF apps would crash the app because the voltage reading became null, this fixes that by wrapping it in a simple try-catch statement.
This is a minor issue since any production version of the app wouldn't have those debugging controls, and it didn't happen without me clicking that button. But I thought it would be nice to have for good measure.